### PR TITLE
SNI support #523

### DIFF
--- a/raven/utils/http.py
+++ b/raven/utils/http.py
@@ -26,21 +26,36 @@ def urlopen(url, data=None, timeout=defaults.TIMEOUT, ca_certs=None,
             httplib.HTTPConnection.__init__(self, *args, **kwargs)
 
         def connect(self):
-            sock = socket.create_connection(
-                address=(self.host, self.port),
-                timeout=self.timeout,
-            )
-            if self._tunnel_host:
-                self.sock = sock
-                self._tunnel()
+            # https://docs.python.org/3/library/ssl.html#socket-creation
+            if sys.version_info > (2, 7, 9) or sys.version_info > (3, 2):
+                context = ssl.create_default_context()
+                context.verify_mode = ssl.CERT_REQUIRED
 
-            self.sock = ssl.wrap_socket(
-                sock, ca_certs=ca_certs, cert_reqs=ssl.CERT_REQUIRED)
+                sock = socket.create_connection(
+                    address=(self.host, self.port),
+                    timeout=self.timeout)
+
+                if self._tunnel_host:
+                    self.sock = sock
+                    self._tunnel()
+
+                self.sock = context.wrap_socket(sock, server_hostname=self.host)
+            else:
+                sock = socket.create_connection(
+                    address=(self.host, self.port),
+                    timeout=self.timeout,
+                )
+                if self._tunnel_host:
+                    self.sock = sock
+                    self._tunnel()
+
+                self.sock = ssl.wrap_socket(
+                    sock, ca_certs=ca_certs, cert_reqs=ssl.CERT_REQUIRED)
 
             if assert_hostname is not None:
                 match_hostname(self.sock.getpeercert(),
                                self.assert_hostname or self.host)
-
+                    
     class ValidHTTPSHandler(urllib2.HTTPSHandler):
         def https_open(self, req):
             return self.do_open(ValidHTTPSConnection, req)


### PR DESCRIPTION
as it mentionned on : https://docs.python.org/3/library/ssl.html#socket-creation

> Since Python 3.2 and 2.7.9, it is recommended to use the SSLContext.wrap_socket() of an SSLContext instance to wrap sockets as SSLSocket objects. The helper functions create_default_context() returns a new context with secure default settings. The old wrap_socket() function is deprecated since it is both inefficient and has no support for server name indication (SNI) and hostname matching.

refactored with version check